### PR TITLE
Quit recommending caret redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,12 +832,6 @@ end
 Redirect stderr to `$my_file`.
 
 ```fish
-my_command ^ $my_file
-```
-
-or
-
-```fish
 my_command 2> $my_file
 ```
 


### PR DESCRIPTION
It's deprecated in 3.0 and will be removed.

Ref: https://github.com/fish-shell/fish-shell/issues/4394