### PR TITLE
Simplify install instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ yum install fish
 <summary>Fedora</summary>
 
 ```bash
-cd /etc/yum.repos.d/
-wget http://download.opensuse.org/repositories/shells:fish:release:2/Fedora_23/shells:fish:release:2.repo
-yum install fish
+dnf install fish
 ```
 
 </details>


### PR DESCRIPTION
Fedora 30+ provides Fish 3.x by default.