### PR TITLE
Fix the getopts link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ for option in $argv
 end
 ```
 
-For a more complete CLI parsing solution, see [`getopts`](https://github.com/fisherman/getopts).
+For a more complete CLI parsing solution, see [`getopts`](https://github.com/jorgebucaran/fish-getopts).
 
 ## Aliases
 


### PR DESCRIPTION
Corrected the link for the fish-getopts project to avoid a redirect.